### PR TITLE
Bump jscs to ^2.0.0

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -3,9 +3,12 @@
   "disallowKeywords": ["with"],
   "disallowMixedSpacesAndTabs": true,
   "disallowMultipleLineStrings": true,
+  "disallowMultipleSpaces": true,
   "disallowMultipleVarDecl": true,
   "disallowSpaceAfterPrefixUnaryOperators": ["++", "--", "+", "-", "~", "!"],
+  "disallowSpaceBeforeComma": true,
   "disallowSpaceBeforePostfixUnaryOperators": ["++", "--"],
+  "disallowSpaceBeforeSemicolon": true,
   "disallowSpacesInCallExpression": true,
   "disallowSpacesInsideBrackets": true,
   "disallowTrailingWhitespace": true,
@@ -15,6 +18,7 @@
   "requireLineFeedAtFileEnd": true,
   "requireOperatorBeforeLineBreak": ["+", "-", "/", "*", "=", "==", "===", "!=", "!==", ">", "<", ">=", "<="],
   "requireParenthesesAroundIIFE": true,
+  "requireSemicolons": true,
   "requireSpaceAfterBinaryOperators": ["+", "-", "/", "*", "=", "==", "===", "!=", "!==", ">", "<", ">=", "<="],
   "requireSpaceAfterKeywords": ["if", "else", "for", "while", "do", "switch", "return", "try", "catch"],
   "requireSpaceBeforeBinaryOperators": ["+", "-", "/", "*", "=", "==", "===", "!=", "!==", ">", "<", ">=", "<="],
@@ -23,6 +27,7 @@
   "requireSpacesInForStatement": true,
   "validateIndentation": 4,
   "validateLineBreaks": "LF",
+  "validateNewlineAfterArrayElements": true,
   "validateParameterSeparator": ", ",
   "plugins": [
     "jscs-jsdoc"

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "coveralls": "^2.11.2",
     "eslint": "^0.24.1",
     "istanbul": "^0.3.14",
-    "jscs": "^1.13.1",
-    "jscs-jsdoc": "^1.0.1",
+    "jscs": "^2.0.0",
+    "jscs-jsdoc": "^1.1.0",
     "jshint": "^2.7.0",
     "mocha": "^2.2.5",
     "mocha-lcov-reporter": "^0.0.2"


### PR DESCRIPTION
Currently blocked on https://github.com/jscs-dev/jscs-jsdoc/issues/128
